### PR TITLE
chore: enable gh-pages for data-exchange-test-service

### DIFF
--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -73,6 +73,14 @@ orgs.newOrg('eclipse-tractusx') {
       allow_update_branch: false,
       secret_scanning_push_protection: "disabled",
       web_commit_signoff_required: false,
+      environments: [
+        orgs.newEnvironment('github-pages') {
+          branch_policies+: [
+            "gh-pages"
+          ],
+          deployment_branch_policy: "selected",
+        },
+      ],
     },
     orgs.newRepo('demand-capacity-mgmt') {
       allow_update_branch: false,


### PR DESCRIPTION
---
name: Enable GitHub Pages for data-exchange-test-service
about: 'Currently branch does not exist and GH Pages are disabled so helm repository is not available and helm chart is not released properly'
title: 'chore: enable gh-pages for data-exchange-test-service'
---

## Description

Thanks for opening this contribution!
_What does this PR introduce? Does it fix a bug? Does it add a new feature? Is it enhancing documentation?_

Currently branch does not exist and GH Pages are disabled so helm repository is not available and helm chart is not released properly

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up to date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] Copyright and license header are present on all affected files

### Additional information

- To request a review, check out [who's involved](https://projects.eclipse.org/projects/automotive.tractusx/who) to see a list of contributors and committers
- Use the [mailing list](https://accounts.eclipse.org/mailing-list/tractusx-dev) if you are unsure, who to contact, or if want to engage in a general discussion
- Check out our guide on [how to contribute](https://eclipse-tractusx.github.io/docs/oss/how-to-contribute)
- Check out our [Release Guidelines](https://eclipse-tractusx.github.io/docs/release)
- Check out the [Eclipse Foundation contribution guidelines](https://www.eclipse.org/projects/handbook/#contributing)
