### PR TITLE
fix: rename repo sig-project-management instead sig-project-managment

### DIFF
--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -436,7 +436,7 @@ orgs.newOrg('eclipse-tractusx') {
       secret_scanning_push_protection: "disabled",
       web_commit_signoff_required: false,
     },
-    orgs.newRepo('sig-project-managment') {
+    orgs.newRepo('sig-project-management') {
       allow_update_branch: false,
       secret_scanning_push_protection: "disabled",
       web_commit_signoff_required: false,


### PR DESCRIPTION
### Description

Fixes [comment from PR](https://github.com/eclipse-tractusx/sig-project-managment/pull/10#issuecomment-1628806009)

### Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up to date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] Copyright and license header are present on all affected files