### PR TITLE
Reference secrets available in cbi pass repo

### DIFF
--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -20,16 +20,16 @@ orgs.newOrg('eclipse-tractusx') {
   },
   secrets+: [
     orgs.newOrgSecret('DOCKER_HUB_TOKEN') {
-      value: "********",
+      value: "pass:bots/automotive.tractusx/docker.com/token",
     },
     orgs.newOrgSecret('DOCKER_HUB_USER') {
-      value: "********",
+      value: "pass:bots/automotive.tractusx/docker.com/username",
     },
     orgs.newOrgSecret('ORG_GPG_PASSPHRASE') {
-      value: "********",
+      value: "pass:bots/automotive.tractusx/gpg/passphrase",
     },
     orgs.newOrgSecret('ORG_GPG_PRIVATE_KEY') {
-      value: "********",
+      value: "pass:bots/automotive.tractusx/gpg/secret-keys.asc",
     },
     orgs.newOrgSecret('ORG_OSSRH_PASSWORD') {
       value: "********",
@@ -44,16 +44,16 @@ orgs.newOrg('eclipse-tractusx') {
       value: "********",
     },
     orgs.newOrgSecret('ORG_VERACODE_API_ID') {
-      value: "********",
+      value: "pass:bots/automotive.tractusx/veracode.com/api-id",
     },
     orgs.newOrgSecret('ORG_VERACODE_API_KEY') {
-      value: "********",
+      value: "pass:bots/automotive.tractusx/veracode.com/api-key",
     },
     orgs.newOrgSecret('VERACODE_API_ID') {
-      value: "********",
+      value: "pass:bots/automotive.tractusx/veracode.com/api-id",
     },
     orgs.newOrgSecret('VERACODE_API_KEY') {
-      value: "********",
+      value: "pass:bots/automotive.tractusx/veracode.com/api-key",
     },
   ],
   _repositories+:: [

--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -32,16 +32,16 @@ orgs.newOrg('eclipse-tractusx') {
       value: "pass:bots/automotive.tractusx/gpg/secret-keys.asc",
     },
     orgs.newOrgSecret('ORG_OSSRH_PASSWORD') {
-      value: "********",
+      value: "pass:bots/automotive.tractusx/oss.sonatype.org/password",
     },
     orgs.newOrgSecret('ORG_OSSRH_USERNAME') {
-      value: "********",
+      value: "pass:bots/automotive.tractusx/oss.sonatype.org/username",
     },
     orgs.newOrgSecret('ORG_PORTAL_DISPATCH_APPID') {
-      value: "********",
+      value: "pass:bots/automotive.tractusx/github.com/github-app-id",
     },
     orgs.newOrgSecret('ORG_PORTAL_DISPATCH_KEY') {
-      value: "********",
+      value: "pass:bots/automotive.tractusx/github.com/github-app-private-key",
     },
     orgs.newOrgSecret('ORG_VERACODE_API_ID') {
       value: "pass:bots/automotive.tractusx/veracode.com/api-id",


### PR DESCRIPTION
I started to reference secrets available in the cbi pass repo, please double check.

There are some duplicates like veracode secrets, and others are not available yet, like sonar or azure credentials. If you know where these secrets are stored atm, please let me know.