### PR TITLE
feat: new repository puris

### DIFF
--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -414,6 +414,12 @@ orgs.newOrg('eclipse-tractusx') {
         },
       ],
     },
+    orgs.newRepo('puris') {
+      allow_update_branch: false,
+      description: "puris",
+      secret_scanning_push_protection: "disabled",
+      web_commit_signoff_required: false,
+    },
     orgs.newRepo('puris-backend') {
       allow_update_branch: false,
       description: "puris-backend",

--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -416,9 +416,17 @@ orgs.newOrg('eclipse-tractusx') {
     },
     orgs.newRepo('puris') {
       allow_update_branch: false,
-      description: "puris",
+      delete_branch_on_merge: true,
+      description: "Predictive Unit Real-Time Information Service (PURIS) for Short Term Demand and Capacity Management",
       secret_scanning_push_protection: "disabled",
       web_commit_signoff_required: false,
+      branch_protection_rules: [
+        orgs.newBranchProtectionRule('main') {
+          required_approving_review_count: 1,
+          requires_status_checks: false,
+          requires_strict_status_checks: true,
+        },
+      ],
     },
     orgs.newRepo('puris-backend') {
       allow_update_branch: false,

--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -423,7 +423,7 @@ orgs.newOrg('eclipse-tractusx') {
       branch_protection_rules: [
         orgs.newBranchProtectionRule('main') {
           required_approving_review_count: 1,
-          requires_status_checks: false,
+          requires_status_checks: true,
           requires_strict_status_checks: true,
         },
       ],

--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -423,7 +423,6 @@ orgs.newOrg('eclipse-tractusx') {
       branch_protection_rules: [
         orgs.newBranchProtectionRule('main') {
           required_approving_review_count: 1,
-          requires_status_checks: true,
           requires_strict_status_checks: true,
         },
       ],


### PR DESCRIPTION
## Description

As discussed in the [Eclipse help desk ticket 3385](https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/3385#note_1178908), we would like to merge the `puris-frontend` and `puris-backend` repository into a new `puris` repository.

This pull requests updates the otterdog configuration to add the new repo.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up to date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] Copyright and license header are present on all affected files
