### PR TITLE
chore: rename sig-project-management to sig-release

### DIFF
--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -436,8 +436,8 @@ orgs.newOrg('eclipse-tractusx') {
       secret_scanning_push_protection: "disabled",
       web_commit_signoff_required: false,
     },
-    orgs.newRepo('sig-project-management') {
-      aliases: ['sig-project-managment'],
+    orgs.newRepo('sig-release') {
+      aliases: ['sig-project-management'],
       allow_update_branch: false,
       secret_scanning_push_protection: "disabled",
       web_commit_signoff_required: false,


### PR DESCRIPTION
### Description

- rename repo after disscussion with @giterrific and @SebastianBezold 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up to date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] Copyright and license header are present on all affected files
