### PR TITLE
Add large files repo for website assets

### DIFF
--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -177,6 +177,10 @@ orgs.newOrg('eclipse-tractusx') {
         },
       ],
     },
+    orgs.newRepo('eclipse-tractusx.github.io.largefiles') {
+      allow_update_branch: false,
+      web_commit_signoff_required: false,
+    },
     orgs.newRepo('item-relationship-service') {
       allow_update_branch: false,
       delete_branch_on_merge: true,


### PR DESCRIPTION
Adding new repo `eclipse-tractusx.github.io.largefiles`, as requested in https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/3499
Git LFS settings have to be configured locally and persisted in `.gitattributes` after repo creation