### PR TITLE
chore: remove puris-frontend and puris-backend repo

### DIFF
--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -462,18 +462,6 @@ orgs.newOrg('eclipse-tractusx') {
         },
       ],
     },
-    orgs.newRepo('puris-backend') {
-      allow_update_branch: false,
-      description: "puris-backend",
-      secret_scanning_push_protection: "disabled",
-      web_commit_signoff_required: false,
-    },
-    orgs.newRepo('puris-frontend') {
-      allow_update_branch: false,
-      description: "puris-frontend",
-      secret_scanning_push_protection: "disabled",
-      web_commit_signoff_required: false,
-    },
     orgs.newRepo('sd-factory') {
       allow_update_branch: false,
       secret_scanning_push_protection: "disabled",

--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -462,6 +462,20 @@ orgs.newOrg('eclipse-tractusx') {
         },
       ],
     },
+    orgs.newRepo('puris-backend') {
+      archived: true,
+      allow_update_branch: false,
+      description: "puris-backend",
+      secret_scanning_push_protection: "disabled",
+      web_commit_signoff_required: false,
+    },
+    orgs.newRepo('puris-frontend') {
+      archived: true,
+      allow_update_branch: false,
+      description: "puris-frontend",
+      secret_scanning_push_protection: "disabled",
+      web_commit_signoff_required: false,
+    },
     orgs.newRepo('sd-factory') {
       allow_update_branch: false,
       secret_scanning_push_protection: "disabled",


### PR DESCRIPTION
As discussed in #10, the new `puris` repository substitutes the old repos `puris-frontend` and `puris-backend`. Since the new repository is created including an initial contribution in https://github.com/eclipse-tractusx/puris/pull/1, the old repositories aren't used anymore and can therefore be deleted.