### PR TITLE
Enable GitHub pages for `sig-release` repo

### DIFF
--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -504,6 +504,17 @@ orgs.newOrg('eclipse-tractusx') {
       has_discussions: true,
       secret_scanning_push_protection: "disabled",
       web_commit_signoff_required: false,
+      gh_pages_build_type: "legacy",
+      gh_pages_source_branch: "gh-pages",
+      gh_pages_source_path: "/",
+      environments: [
+          orgs.newEnvironment('github-pages') {
+            branch_policies+: [
+              "gh-pages"
+            ],
+            deployment_branch_policy: "selected",
+          },
+      ],
     },
     orgs.newRepo('sldt-bpn-discovery') {
       allow_update_branch: false,

--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -504,6 +504,7 @@ orgs.newOrg('eclipse-tractusx') {
       has_discussions: true,
       secret_scanning_push_protection: "disabled",
       web_commit_signoff_required: false,
+      homepage: "https://eclipse-tractusx.github.io/sig-release",
       gh_pages_build_type: "legacy",
       gh_pages_source_branch: "gh-pages",
       gh_pages_source_path: "/",


### PR DESCRIPTION
## Description

This PR enables GitHub pages for the [sig-release](https://github.com/eclipse-tractusx/sig-release) repo.
Settings are "copied" from other repos with enabled GitHub pages

We are currently building automation, that runs checks on our org and compiles the results to a statically generated dashboard. This dashboard should be hosted via GitHub pages.

FYI: @Siegfriedk 
