### PR TITLE
chore: delete dmc frontend backend repo

### DIFF
--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -136,6 +136,18 @@ orgs.newOrg('eclipse-tractusx') {
       secret_scanning_push_protection: "disabled",
       web_commit_signoff_required: false,
     },
+    orgs.newRepo('demand-capacity-mgmt-backend') {
+      archived: true,
+      allow_update_branch: false,
+      secret_scanning_push_protection: "disabled",
+      web_commit_signoff_required: false,
+    },
+    orgs.newRepo('demand-capacity-mgmt-frontend') {
+      archived: true,
+      allow_update_branch: false,
+      secret_scanning_push_protection: "disabled",
+      web_commit_signoff_required: false,
+    },
     orgs.newRepo('digital-product-pass') {
       allow_update_branch: false,
       description: "digital product pass",

--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -136,16 +136,6 @@ orgs.newOrg('eclipse-tractusx') {
       secret_scanning_push_protection: "disabled",
       web_commit_signoff_required: false,
     },
-    orgs.newRepo('demand-capacity-mgmt-backend') {
-      allow_update_branch: false,
-      secret_scanning_push_protection: "disabled",
-      web_commit_signoff_required: false,
-    },
-    orgs.newRepo('demand-capacity-mgmt-frontend') {
-      allow_update_branch: false,
-      secret_scanning_push_protection: "disabled",
-      web_commit_signoff_required: false,
-    },
     orgs.newRepo('digital-product-pass') {
       allow_update_branch: false,
       description: "digital product pass",


### PR DESCRIPTION
The DMC Team decided to use only one (already existing repo): demand-capacity-mgmt.

## Description

Fixes https://github.com/eclipse-tractusx/sig-infra/issues/223

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
