### PR TITLE
chore: add new repository

### DIFF
--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -226,6 +226,11 @@ orgs.newOrg('eclipse-tractusx') {
       secret_scanning_push_protection: "disabled",
       web_commit_signoff_required: false,
     },
+    orgs.newRepo('knowledge-agents-aas-bridge') {
+      allow_update_branch: false,
+      secret_scanning_push_protection: "disabled",
+      web_commit_signoff_required: false,
+    },
     orgs.newRepo('knowledge-agents-edc') {
       allow_update_branch: false,
       secret_scanning_push_protection: "disabled",


### PR DESCRIPTION
add new repository `knowledge-agents-aas-bridge` to eclipse-tractusx GH org as requested in eclipse-tractusx/sig-infra#240