### PR TITLE
chore: added discussion section to tutorial-resources repo

### DIFF
--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -749,6 +749,7 @@ orgs.newOrg('eclipse-tractusx') {
       gh_pages_build_type: "legacy",
       gh_pages_source_branch: "gh-pages",
       gh_pages_source_path: "/",
+      has_discussions: true,
       web_commit_signoff_required: false,
       environments: [
         orgs.newEnvironment('github-pages') {


### PR DESCRIPTION
# What

Currently, the discussion section for [tutorial-resources](https://github.com/eclipse-tractusx/tutorial-resources) is not activated. This PR activates the section.

# Why

Discussions are needed for development