### PR TITLE
chore: disable projects on repo sig-release

### DIFF
--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -581,6 +581,7 @@ orgs.newOrg('eclipse-tractusx') {
       gh_pages_source_branch: "gh-pages",
       gh_pages_source_path: "/",
       has_discussions: true,
+      has_projects: false,
       homepage: "https://eclipse-tractusx.github.io/sig-release",
       web_commit_signoff_required: false,
       environments: [


### PR DESCRIPTION
## Description
- disable projects on repo base

## Visaualisation

![image](https://github.com/eclipse-tractusx/.eclipsefdn/assets/121097161/02fed7dd-358e-45dc-8784-8805e98de14e)

## Based on current infoamtion

https://eclipse-tractusx.github.io/.eclipsefdn/repo-sig-release/

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
