### PR TITLE
chore: add tractusx metadata

### DIFF
--- a/.tractusx
+++ b/.tractusx
@@ -1,0 +1,25 @@
+###############################################################
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+###############################################################
+product: ".eclipsefdn"
+leadingRepository: "https://github.com/eclipse-tractusx/.eclipsefdn"
+repoCategory: "support"
+repositories:
+  - name: ".eclipsefdn"
+    usage: "Repository to host configurations related to the Eclipse Foundation."
+    url: "https://github.com/eclipse-tractusx/.eclipsefdn"


### PR DESCRIPTION
## Description

PR to add tractusx metadata following https://eclipse-tractusx.github.io/docs/release/trg-2/trg-2-5. 


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
