### PR TITLE
chore: add new bpdm-certificate-management repo

### DIFF
--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -95,6 +95,13 @@ orgs.newOrg('eclipse-tractusx') {
       description: "bpdm",
       web_commit_signoff_required: false,
     },
+    orgs.newRepo('bpdm-certificate-management') {
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      delete_branch_on_merge: false,
+      description: "reference implementation for business partner certificates",
+      web_commit_signoff_required: false,
+    },
     orgs.newRepo('charts') {
       allow_merge_commit: true,
       allow_update_branch: false,


### PR DESCRIPTION
## Description

Adding a new uninitialized repo `bpdm-certificate-management`, liked requested in eclipse-tractusx/sig-infra#310 


FYI @SujitMBRDI , @nicoprow. Please initialize the repository with at least the legal docs, as soon as it is created
