### PR TITLE
chore: archive standalone KIT repos

### DIFF
--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -252,6 +252,7 @@ orgs.newOrg('eclipse-tractusx') {
       },
     },
     orgs.newRepo('eco-pass-kit') {
+      archived: true,
       allow_merge_commit: true,
       allow_update_branch: false,
       delete_branch_on_merge: false,
@@ -492,6 +493,7 @@ orgs.newOrg('eclipse-tractusx') {
       ],
     },
     orgs.newRepo('online-simulation-kit') {
+      archived: true,
       allow_merge_commit: true,
       allow_update_branch: false,
       delete_branch_on_merge: false,
@@ -502,6 +504,7 @@ orgs.newOrg('eclipse-tractusx') {
       },
     },
     orgs.newRepo('pcf-exchange-kit') {
+      archived: true,
       allow_merge_commit: true,
       allow_update_branch: false,
       delete_branch_on_merge: false,

--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -492,27 +492,6 @@ orgs.newOrg('eclipse-tractusx') {
         },
       ],
     },
-    orgs.newRepo('online-simulation-kit') {
-      archived: true,
-      allow_merge_commit: true,
-      allow_update_branch: false,
-      delete_branch_on_merge: false,
-      has_discussions: true,
-      web_commit_signoff_required: false,
-      workflows+: {
-        default_workflow_permissions: "write",
-      },
-    },
-    orgs.newRepo('pcf-exchange-kit') {
-      archived: true,
-      allow_merge_commit: true,
-      allow_update_branch: false,
-      delete_branch_on_merge: false,
-      web_commit_signoff_required: false,
-      workflows+: {
-        default_workflow_permissions: "write",
-      },
-    },
     orgs.newRepo('policy-hub') {
       allow_merge_commit: true,
       allow_update_branch: false,


### PR DESCRIPTION
## Description

There are some standalone KIT repositories, containing some markdown files. The exact same files are used to build our [eclipse-tractusx.github.io](https://eclipse-tractusx.github.io/) website. 
This means we are duplicating content and even add more maintenance effort for keeping legal documentation up-to-date.

The repositories in question are:

- [eclipse-tractusx/eco-pass-kit](https://github.com/eclipse-tractusx/eco-pass-kit)
- [eclipse-tractusx/pcf-exchange-kit](https://github.com/eclipse-tractusx/pcf-exchange-kit)
- [eclipse-tractusx/online-simulation-kit](https://github.com/eclipse-tractusx/online-simulation-kit)

The KITs representation on our webiste:

- [Eco Pass KIT](https://eclipse-tractusx.github.io/docs-kits/kits/Eco_Pass_KIT/page-adoption-view)
- [PCF Exchange KIT](https://eclipse-tractusx.github.io/docs-kits/kits/PCF%20Exchange%20Kit/Adoption%20View)
- [OSim KIT](https://eclipse-tractusx.github.io/docs-kits/kits/OSim%20Kit/Adoption%20View%20OSim%20Kit)

## Further notes

@netomi: How would I completely DELETE a repository? Will removing the entry completely do the trick, or will it just make the repo "unmanaged"? I think `pcf-exchange-kit` and `online-simulation-kit` could be deleted, since there is no content yet in the repo, while the KITs are already represented on the website

## Related issues

Closes eclipse-tractusx/pcf-exchange-kit#4
Closes eclipse-tractusx/online-simulation-kit#2