### PR TITLE
chore: rename e2e-testing repo to tractus-x-umbrella

### DIFF
--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -195,7 +195,7 @@ orgs.newOrg('eclipse-tractusx') {
         default_workflow_permissions: "write",
       },
     },
-    orgs.newRepo('e2e-testing') {
+    orgs.newRepo('tractus-x-umbrella') {
       allow_merge_commit: true,
       allow_update_branch: false,
       delete_branch_on_merge: false,

--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -196,6 +196,7 @@ orgs.newOrg('eclipse-tractusx') {
       },
     },
     orgs.newRepo('tractus-x-umbrella') {
+      aliases: ['e2e-testing'],
       allow_merge_commit: true,
       allow_update_branch: false,
       delete_branch_on_merge: false,


### PR DESCRIPTION
## Description

- rename e2e-testing repo to tractus-x-umbrella

fixes https://github.com/eclipse-tractusx/sig-infra/issues/427

FYI @almadigabor @evegufy 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
