### PR TITLE
chore: rename portal-cd repository to portal

### DIFF
--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -596,10 +596,11 @@ orgs.newOrg('eclipse-tractusx') {
         orgs.newEnvironment('int'),
       ],
     },
-    orgs.newRepo('portal-cd') {
+    orgs.newRepo('portal') {
+      aliases: ['portal-cd'],
       allow_merge_commit: true,
       allow_update_branch: false,
-      description: "Portal - Continuous Deployment",
+      description: "Portal - Helm charts",
       web_commit_signoff_required: false,
       workflows+: {
         default_workflow_permissions: "write",


### PR DESCRIPTION
## Description

- rename portal-cd repository to portal

addresses https://github.com/eclipse-tractusx/portal-cd/issues/131

FYI: @Siegfriedk @SebastianBezold @carslen @FaGru3n 

## Pre-review checks

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
