### PR TITLE
chore: request new repository for BPN<>DID resolution service

### DIFF
--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -1159,6 +1159,20 @@ orgs.newOrg('eclipse-tractusx') {
         },
       ],
     },
+    orgs.newRepo('bpn-did-resolution-service') {
+        description: "Tractus-X Resolver Service for BPN <> DID resolution",
+        delete_branch_on_merge: false,
+        allow_merge_commit: false,
+        has_discussions: false,
+        secrets : [
+          orgs.newRepoSecret('GPG_PASSPHRASE') {
+            value: "<NOT_SURE_WHAT_TO_PUT_HERE>",
+          },
+          orgs.newRepoSecret('GPG_PRIVATE_KEY') {
+            value: "<NOT_SURE_WHAT_TO_PUT_HERE>",
+          },
+        ]
+    },
     orgs.newRepo('tractusx-edc-template'){
       is_template: true,
       delete_branch_on_merge: false,

--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -1164,14 +1164,6 @@ orgs.newOrg('eclipse-tractusx') {
         delete_branch_on_merge: false,
         allow_merge_commit: false,
         has_discussions: false,
-        secrets : [
-          orgs.newRepoSecret('GPG_PASSPHRASE') {
-            value: "<NOT_SURE_WHAT_TO_PUT_HERE>",
-          },
-          orgs.newRepoSecret('GPG_PRIVATE_KEY') {
-            value: "<NOT_SURE_WHAT_TO_PUT_HERE>",
-          },
-        ]
     },
     orgs.newRepo('tractusx-edc-template'){
       is_template: true,


### PR DESCRIPTION
## Description
This PR requests a new repository `bpn-did-resolution-service` which is a Tractus-X shared service that will provide a scalable functionality to resolve BPN (Business Partner Number) -> DID (Decentralized Identifier).

Tractus-X uses BPNs as stable identifiers, but DID are used to represent the participant in an self-sovereign-identity context. Thus a resolution is necessary.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
