### PR TITLE
fix(auth): use OSSRH's tokenbased auth

### DIFF
--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -35,10 +35,10 @@ orgs.newOrg('eclipse-tractusx') {
       value: "pass:bots/automotive.tractusx/gpg/secret-subkeys.asc",
     },
     orgs.newOrgSecret('ORG_OSSRH_PASSWORD') {
-      value: "pass:bots/automotive.tractusx/oss.sonatype.org/password",
+      value: "pass:bots/automotive.tractusx/oss.sonatype.org/gh-token-password",
     },
     orgs.newOrgSecret('ORG_OSSRH_USERNAME') {
-      value: "pass:bots/automotive.tractusx/oss.sonatype.org/username",
+      value: "pass:bots/automotive.tractusx/oss.sonatype.org/gh-token-username",
     },
     orgs.newOrgSecret('ORG_PORTAL_DISPATCH_APPID') {
       value: "pass:bots/automotive.tractusx/github.com/github-app-id",


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
This PR moves the currently-used username/password based auth over to using token-based auth, as required by OSSRH

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

please find related information in this [EF helpdesk issue](https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/4733)

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
