### PR TITLE
fix(puris): use syntax for reusable workflow for CodeQl

### DIFF
--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -819,7 +819,7 @@ orgs.newOrg('eclipse-tractusx') {
           required_status_checks+: [
             "docker-frontend",
             "docker-backend",
-            "Analyze CodeQl",
+            "CodeQl / Analyze CodeQl",
             "Analyze KICS",
             "check-dependencies-frontend",
             "check-dependencies-backend",


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

Recent pr #81 didn't consider CodeQl workflow as a reused one (wrong).

This pr handles CodeQl as reusable workflow (correct, following the results in this [pr](https://github.com/eclipse-tractusx/puris/pull/450)).

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
