### PR TITLE
chore: archive BPDM upload tool and country risk backend

### DIFF
--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -158,6 +158,7 @@ orgs.newOrg('eclipse-tractusx') {
       },
     },
     orgs.newRepo('bpdm-upload-tool') {
+      archived: true,
       allow_merge_commit: true,
       allow_update_branch: false,
       delete_branch_on_merge: false,
@@ -1482,6 +1483,7 @@ orgs.newOrg('eclipse-tractusx') {
       ],
     },
     orgs.newRepo('vas-country-risk-backend') {
+      archived: true,
       allow_merge_commit: true,
       allow_update_branch: false,
       delete_branch_on_merge: false,


### PR DESCRIPTION
## Description

This PR will set [bpdm-upload-tool](https://github.com/eclipse-tractusx/bpdm-upload-tool) and [vas-country-risk-backend](https://github.com/eclipse-tractusx/vas-country-risk-backend) to public archive.

[bpdm-upload-tool](https://github.com/eclipse-tractusx/bpdm-upload-tool) is not maintained as of now and only contains the initial contribution.

[vas-country-risk-backend](https://github.com/eclipse-tractusx/vas-country-risk-backend) has been integrated in the monorepo [vas-country-risk](https://github.com/eclipse-tractusx/vas-country-risk)
