### PR TITLE
chore: delete uninitialized repos

### DIFF
--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -824,16 +824,6 @@ orgs.newOrg('eclipse-tractusx') {
         default_workflow_permissions: "write",
       },
     },
-    orgs.newRepo('quality-dashboard') {
-      allow_merge_commit: true,
-      allow_update_branch: false,
-      delete_branch_on_merge: false,
-      private_vulnerability_reporting_enabled: true,
-      web_commit_signoff_required: false,
-      workflows+: {
-        default_workflow_permissions: "write",
-      },
-    },
     orgs.newRepo('sd-factory') {
       allow_merge_commit: true,
       allow_update_branch: false,
@@ -901,18 +891,6 @@ orgs.newOrg('eclipse-tractusx') {
       ],
     },
     orgs.newRepo('sig-security') {
-      allow_merge_commit: true,
-      allow_update_branch: false,
-      delete_branch_on_merge: false,
-      dependabot_security_updates_enabled: true,
-      has_discussions: true,
-      private_vulnerability_reporting_enabled: true,
-      web_commit_signoff_required: false,
-      workflows+: {
-        default_workflow_permissions: "write",
-      },
-    },
-    orgs.newRepo('sig-testing') {
       allow_merge_commit: true,
       allow_update_branch: false,
       delete_branch_on_merge: false,


### PR DESCRIPTION
## Description

This PR deletes two unmaintained repositories. They are deleted instead of archived, because they are not even initialized.

Repos to delete: 

- [eclipse-tractusx/sig-testing](https://github.com/eclipse-tractusx/sig-testing)
- [eclipse-tractusx/quality-dashboard](https://github.com/eclipse-tractusx/quality-dashboard) -> Legal docs initialized 8 months ago. No activity since then
