### PR TITLE
Allow the use of macos large runners

### DIFF
--- a/otterdog/policies/macos_large_runners.yml
+++ b/otterdog/policies/macos_large_runners.yml
@@ -1,0 +1,4 @@
+name: Limit use of macos larger runners
+type: macos_large_runners
+config:
+  allowed: true


### PR DESCRIPTION
This PR allows the use of macos large runners in this organization as it has now been disabled by default for all orgs.