### PR TITLE
chore(number of reviewer): adapt review configuration for github.io

### DIFF
--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -316,6 +316,7 @@ orgs.newOrg('eclipse-tractusx') {
       },
       branch_protection_rules: [
         orgs.newBranchProtectionRule('main') {
+          required_approving_review_count: 1,
           dismisses_stale_reviews: true,
         },
       ],


### PR DESCRIPTION
## Description

This PR enables one committer review for the github.io repository, instead of currently two committer reviews.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
