### PR TITLE
feat(prs): block failing build for github pages

### DIFF
--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -318,6 +318,9 @@ orgs.newOrg('eclipse-tractusx') {
         orgs.newBranchProtectionRule('main') {
           required_approving_review_count: 1,
           dismisses_stale_reviews: true,
+      	  required_status_checks+: [
+      		  "Build and deploy to GitHub Pages"
+      	  ],
         },
       ],
       environments: [


### PR DESCRIPTION
## Description
We want to force the build for our main tractus-x webpage to be working and block the merge if not.

Workflow: https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/blob/main/.github/workflows/build-and-deploy-gh-pages.yaml#L30C11-L30C43

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files

Closes eclipse-tractusx/eclipse-tractusx.github.io#1067
