### PR TITLE
feat: new repo for tractus-x edc compatibility tests

### DIFF
--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -1486,9 +1486,6 @@ orgs.newOrg('eclipse-tractusx') {
       delete_branch_on_merge: false,
       private_vulnerability_reporting_enabled: true,
       web_commit_signoff_required: false,
-      workflows+: {
-        default_workflow_permissions: "read",
-      },
     },
     orgs.newRepo('tractusx-edc-template') {
       delete_branch_on_merge: false,

--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -1477,6 +1477,19 @@ orgs.newOrg('eclipse-tractusx') {
         },
       ],
     },
+    orgs.newRepo('tractusx-edc-compatibility-tests') {
+      description: "Compatibility tests for Tractus-X EDC",
+      allow_merge_commit: true,
+      dependabot_alerts_enabled: true,
+      dependabot_security_updates_enabled: true,
+      allow_update_branch: false,
+      delete_branch_on_merge: false,
+      private_vulnerability_reporting_enabled: true,
+      web_commit_signoff_required: false,
+      workflows+: {
+        default_workflow_permissions: "read",
+      },
+    },
     orgs.newRepo('tractusx-edc-template') {
       delete_branch_on_merge: false,
       is_template: true,


### PR DESCRIPTION
## Description

New repo for tractusx edc compatibility tests

Ref: https://github.com/eclipse-tractusx/sig-release/issues/908

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
