### PR TITLE
chore(branch protection): switch the action we are waiting for

### DIFF
--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -319,7 +319,7 @@ orgs.newOrg('eclipse-tractusx') {
           required_approving_review_count: 1,
           dismisses_stale_reviews: true,
       	  required_status_checks+: [
-      		  "Build and deploy to GitHub Pages"
+      		  "Build static website"
       	  ],
         },
       ],

--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -319,7 +319,7 @@ orgs.newOrg('eclipse-tractusx') {
           required_approving_review_count: 1,
           dismisses_stale_reviews: true,
       	  required_status_checks+: [
-      		  "Build static website"
+      		  "Verify website build"
       	  ],
         },
       ],


### PR DESCRIPTION
## Description
This PR changes the action we are waiting for. 

- `Build static website`-> correct one -> checks if it is possible to build the page
- `Build and deploy to GitHub Pages`->  wrong one -> Builds and deploy to gh-pages after merge

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
