### PR TITLE
feat(sig-architecture): created sig-architecture repository

### DIFF
--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -882,6 +882,11 @@ orgs.newOrg('eclipse-tractusx') {
       workflows+: {
         default_workflow_permissions: "write",
       },
+      branch_protection_rules: [
+        orgs.newBranchProtectionRule('main') {
+          required_approving_review_count: 1
+        }
+      ]
     },
     orgs.newRepo('sig-infra') {
       allow_merge_commit: true,

--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -874,7 +874,7 @@ orgs.newOrg('eclipse-tractusx') {
       gh_pages_source_branch: "gh-pages",
       gh_pages_source_path: "/",
       delete_branch_on_merge: false,
-      description: "Repository for Eclipse Tractus-X™ Architecture topics, documenting the dataspace technology general architecture and overall design decisions.",
+      description: "Eclipse Tractus-X Architecture topics, general architecture documentation and overall design decisions.",
       has_discussions: true,
       homepage: "",
       private_vulnerability_reporting_enabled: true,

--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -874,7 +874,7 @@ orgs.newOrg('eclipse-tractusx') {
       gh_pages_source_branch: "gh-pages",
       gh_pages_source_path: "/",
       delete_branch_on_merge: false,
-      description: "Repository for Tractus-X Architecture topics, documenting Tractus-X general architecture and overall design decisions.",
+      description: "Repository for Eclipse Tractus-X™ Architecture topics, documenting the dataspace technology general architecture and overall design decisions.",
       has_discussions: true,
       homepage: "",
       private_vulnerability_reporting_enabled: true,
@@ -886,6 +886,14 @@ orgs.newOrg('eclipse-tractusx') {
         orgs.newBranchProtectionRule('main') {
           required_approving_review_count: 1
         }
+      ],
+      environments: [
+        orgs.newEnvironment('github-pages') {
+          branch_policies+: [
+            "gh-pages"
+          ],
+          deployment_branch_policy: "selected",
+        },
       ]
     },
     orgs.newRepo('sig-infra') {

--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -867,6 +867,22 @@ orgs.newOrg('eclipse-tractusx') {
         },
       ],
     },
+    orgs.newRepo('sig-architecture') {
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      gh_pages_build_type: "legacy",
+      gh_pages_source_branch: "gh-pages",
+      gh_pages_source_path: "/",
+      delete_branch_on_merge: false,
+      description: "Repository for Tractus-X Architecture topics, documenting Tractus-X general architecture and overall design decisions.",
+      has_discussions: true,
+      homepage: "",
+      private_vulnerability_reporting_enabled: true,
+      web_commit_signoff_required: false,
+      workflows+: {
+        default_workflow_permissions: "write",
+      },
+    },
     orgs.newRepo('sig-infra') {
       allow_merge_commit: true,
       allow_update_branch: false,


### PR DESCRIPTION
## Description
Since we are starting to scale the  Eclipse Tractus-X product to other dataspaces rather than just Catena-X, we need to start documenting the overall architecture and  here we can come together as multiple organizations to find a way forward in  fitting the general dataspace architecture of Tractus-X Manufacturing.

Closes #110 

## Added
- Added the sig-architecture repository, and basic description
- I enabled the github pages, so we can also add some static documentation.
- Added discussions so  we can  have threads to  discuss the architecture topics with the community
- Copied the configuration format from other "sig-*" repositories.

## Pre-review checks

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
