### PR TITLE
feat: added the industry core hub repo

### DIFF
--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -279,9 +279,6 @@ orgs.newOrg('automotive.tractusx', 'eclipse-tractusx') {
       homepage: "https://github.com/eclipse-tractusx/industry-core-hub",
       private_vulnerability_reporting_enabled: true,
       web_commit_signoff_required: false,
-      workflows+: {
-        default_workflow_permissions: "read",
-      },
       environments: [
         orgs.newEnvironment('github-pages') {
           branch_policies+: [

--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -266,6 +266,31 @@ orgs.newOrg('automotive.tractusx', 'eclipse-tractusx') {
         default_workflow_permissions: "write",
       },
     },
+    orgs.newRepo('industry-core-hub') {
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      delete_branch_on_merge: false,
+      dependabot_security_updates_enabled: true,
+      description: "Eclipse Tractus-X Industry Core Hub [IC-Hub] - The Tractus-X Use Case Speedway",
+      gh_pages_build_type: "legacy",
+      gh_pages_source_branch: "gh-pages",
+      gh_pages_source_path: "/",
+      has_discussions: true,
+      homepage: "https://github.com/eclipse-tractusx/industry-core-hub",
+      private_vulnerability_reporting_enabled: true,
+      web_commit_signoff_required: false,
+      workflows+: {
+        default_workflow_permissions: "write",
+      },
+      environments: [
+        orgs.newEnvironment('github-pages') {
+          branch_policies+: [
+            "gh-pages"
+          ],
+          deployment_branch_policy: "selected",
+        },
+      ],
+    },
     orgs.newRepo('digital-product-pass') {
       allow_merge_commit: true,
       allow_update_branch: false,

--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -280,7 +280,7 @@ orgs.newOrg('automotive.tractusx', 'eclipse-tractusx') {
       private_vulnerability_reporting_enabled: true,
       web_commit_signoff_required: false,
       workflows+: {
-        default_workflow_permissions: "write",
+        default_workflow_permissions: "read",
       },
       environments: [
         orgs.newEnvironment('github-pages') {


### PR DESCRIPTION
## Description
In this repository will be hosted the new Industry Core Reference Implementation, called Industry Core Hub.

It will act as provider and consumer and provider a speed way for use cases that use it.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
