### PR TITLE
feat: added tractus-x sdk repo for industry core hub

### DIFF
--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -268,6 +268,28 @@ orgs.newOrg('automotive.tractusx', 'eclipse-tractusx') {
         default_workflow_permissions: "write",
       },
     },
+    orgs.newRepo('tractusx-sdk') {
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      delete_branch_on_merge: false,
+      dependabot_security_updates_enabled: true,
+      description: "Eclipse Tractus-X Software Development KIT - The industry and dataspace middleware",
+      gh_pages_build_type: "legacy",
+      gh_pages_source_branch: "gh-pages",
+      gh_pages_source_path: "/",
+      has_discussions: true,
+      homepage: "https://eclipse-tractusx.github.io/tractusx-sdk/",
+      private_vulnerability_reporting_enabled: true,
+      web_commit_signoff_required: false,
+      environments: [
+        orgs.newEnvironment('github-pages') {
+          branch_policies+: [
+            "gh-pages"
+          ],
+          deployment_branch_policy: "selected",
+        },
+      ],
+    },
     orgs.newRepo('industry-core-hub') {
       allow_merge_commit: true,
       allow_update_branch: false,

--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -273,7 +273,7 @@ orgs.newOrg('automotive.tractusx', 'eclipse-tractusx') {
       allow_update_branch: false,
       delete_branch_on_merge: false,
       dependabot_security_updates_enabled: true,
-      description: "Eclipse Tractus-X Software Development KIT - The industry and dataspace middleware",
+      description: "Eclipse Tractus-X Software Development KIT - The Dataspace & Industry Foundation Middleware",
       gh_pages_build_type: "legacy",
       gh_pages_source_branch: "gh-pages",
       gh_pages_source_path: "/",


### PR DESCRIPTION
## Description

As aligned and refined in the sig-release feature: https://github.com/eclipse-tractusx/sig-release/issues/1161

And aligned with the community in the office hour and in the open meeting from the Industry Core Hub, there will be shifted the following folder: https://github.com/eclipse-tractusx/industry-core-hub/tree/main/tractusx_sdk

To a separated repository, following the pattern from the "Portal" which have multiple repositories for multiple components. In this case if you use the tractus-x sdk it will not be only restricted or attached to the Industry core hub repo.

It was proposed and included today during the Open Source Refinement for R25.06 our MVP target release.

The industry core hub will be the first "lighthouse" implementation of that tractus-x sdk. So it can be reused by other use cases and add-ons.

Both for applications that want to implement a "backend" using the SDK, and applications that want to implement a "frontend" using the SDK apis.

Design Decision:

- Creation of a SDK: https://github.com/eclipse-tractusx/industry-core-hub/blob/main/docs/architecture/decision-records/0002-tractus-x-sdk.md
- Moving the SDK to another repo: https://github.com/eclipse-tractusx/industry-core-hub/blob/main/docs/architecture/decision-records/0003-tractus-x-sdk-individual-repository.md


Our defined new structure, so more use cases and repositories can use us:

![image](https://github.com/user-attachments/assets/178b5804-9bf3-4765-b563-7a0c9b389f39)


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
