### PR TITLE
chore(github.io): temporarily lock main branch on github.io

### DIFF
--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -325,6 +325,7 @@ orgs.newOrg('automotive.tractusx', 'eclipse-tractusx') {
         orgs.newBranchProtectionRule('main') {
           dismisses_stale_reviews: true,
           required_approving_review_count: 1,
+          lock_branch: true,
         },
       ],
       environments: [


### PR DESCRIPTION
## Description

This PR should set main “read_only” for a small time period. Because we have a bigger maintenance phase and don't want to have other changes on main.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
