### PR TITLE
feat/aas-suite: Added new repository for integrating and generating a common runtime between BaSyx & Tractus-X SDK

### DIFF
--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -289,17 +289,17 @@ orgs.newOrg('automotive.tractusx', 'eclipse-tractusx') {
         default_workflow_permissions: "write",
       },
     },
-    orgs.newRepo('digital-twin-suite') {
+    orgs.newRepo('aas-suite') {
       allow_merge_commit: true,
       allow_update_branch: false,
       delete_branch_on_merge: false,
       dependabot_security_updates_enabled: true,
-      description: "Eclipse Tractus-X Digital Twin Suite [DTS] - An integration between BaSyx & Tractus-X Python SDKs",
+      description: "Eclipse Tractus-X Asset Administration Shell Suite [AAS Suite] - An integration between BaSyx & Tractus-X Python SDKs",
       gh_pages_build_type: "legacy",
       gh_pages_source_branch: "gh-pages",
       gh_pages_source_path: "/",
       has_discussions: true,
-      homepage: "https://github.com/eclipse-tractusx/digital-twin-suite",
+      homepage: "https://github.com/eclipse-tractusx/aas-suite",
       private_vulnerability_reporting_enabled: true,
       web_commit_signoff_required: false,
       environments: [

--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -311,28 +311,6 @@ orgs.newOrg('automotive.tractusx', 'eclipse-tractusx') {
         },
       ],
     },
-    orgs.newRepo('industry-core-hub') {
-      allow_merge_commit: true,
-      allow_update_branch: false,
-      delete_branch_on_merge: false,
-      dependabot_security_updates_enabled: true,
-      description: "Eclipse Tractus-X Industry Core Hub [IC-Hub] - The Tractus-X Use Case Speedway",
-      gh_pages_build_type: "legacy",
-      gh_pages_source_branch: "gh-pages",
-      gh_pages_source_path: "/",
-      has_discussions: true,
-      homepage: "https://github.com/eclipse-tractusx/industry-core-hub",
-      private_vulnerability_reporting_enabled: true,
-      web_commit_signoff_required: false,
-      environments: [
-        orgs.newEnvironment('github-pages') {
-          branch_policies+: [
-            "gh-pages"
-          ],
-          deployment_branch_policy: "selected",
-        },
-      ],
-    },
     orgs.newRepo('digital-product-pass') {
       allow_merge_commit: true,
       allow_update_branch: false,

--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -289,6 +289,28 @@ orgs.newOrg('automotive.tractusx', 'eclipse-tractusx') {
         default_workflow_permissions: "write",
       },
     },
+    orgs.newRepo('digital-twin-suite') {
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      delete_branch_on_merge: false,
+      dependabot_security_updates_enabled: true,
+      description: "Eclipse Tractus-X Digital Twin Suite [DTS] - An integration between BaSyx & Tractus-X Python SDKs",
+      gh_pages_build_type: "legacy",
+      gh_pages_source_branch: "gh-pages",
+      gh_pages_source_path: "/",
+      has_discussions: true,
+      homepage: "https://github.com/eclipse-tractusx/digital-twin-suite",
+      private_vulnerability_reporting_enabled: true,
+      web_commit_signoff_required: false,
+      environments: [
+        orgs.newEnvironment('github-pages') {
+          branch_policies+: [
+            "gh-pages"
+          ],
+          deployment_branch_policy: "selected",
+        },
+      ],
+    },
     orgs.newRepo('industry-core-hub') {
       allow_merge_commit: true,
       allow_update_branch: false,

--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -279,9 +279,6 @@ orgs.newOrg('automotive.tractusx', 'eclipse-tractusx') {
       homepage: "https://github.com/eclipse-tractusx/industry-core-hub",
       private_vulnerability_reporting_enabled: true,
       web_commit_signoff_required: false,
-      workflows+: {
-        default_workflow_permissions: "read",
-      },
       environments: [
         orgs.newEnvironment('github-pages') {
           branch_policies+: [

--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -266,6 +266,31 @@ orgs.newOrg('automotive.tractusx', 'eclipse-tractusx') {
         default_workflow_permissions: "write",
       },
     },
+    orgs.newRepo('industry-core-hub') {
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      delete_branch_on_merge: false,
+      dependabot_security_updates_enabled: true,
+      description: "Eclipse Tractus-X Industry Core Hub [IC-Hub] - The Tractus-X Use Case Speedway",
+      gh_pages_build_type: "legacy",
+      gh_pages_source_branch: "gh-pages",
+      gh_pages_source_path: "/",
+      has_discussions: true,
+      homepage: "https://github.com/eclipse-tractusx/industry-core-hub",
+      private_vulnerability_reporting_enabled: true,
+      web_commit_signoff_required: false,
+      workflows+: {
+        default_workflow_permissions: "write",
+      },
+      environments: [
+        orgs.newEnvironment('github-pages') {
+          branch_policies+: [
+            "gh-pages"
+          ],
+          deployment_branch_policy: "selected",
+        },
+      ],
+    },
     orgs.newRepo('digital-product-pass') {
       allow_merge_commit: true,
       allow_update_branch: false,

--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -280,7 +280,7 @@ orgs.newOrg('automotive.tractusx', 'eclipse-tractusx') {
       private_vulnerability_reporting_enabled: true,
       web_commit_signoff_required: false,
       workflows+: {
-        default_workflow_permissions: "write",
+        default_workflow_permissions: "read",
       },
       environments: [
         orgs.newEnvironment('github-pages') {

--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -289,7 +289,7 @@ orgs.newOrg('automotive.tractusx', 'eclipse-tractusx') {
         default_workflow_permissions: "write",
       },
     },
-    orgs.newRepo('aas-suite') {
+    orgs.newRepo('aas-suite-python') {
       allow_merge_commit: true,
       allow_update_branch: false,
       delete_branch_on_merge: false,
@@ -299,7 +299,7 @@ orgs.newOrg('automotive.tractusx', 'eclipse-tractusx') {
       gh_pages_source_branch: "gh-pages",
       gh_pages_source_path: "/",
       has_discussions: true,
-      homepage: "https://github.com/eclipse-tractusx/aas-suite",
+      homepage: "https://github.com/eclipse-tractusx/aas-suite-python",
       private_vulnerability_reporting_enabled: true,
       web_commit_signoff_required: false,
       environments: [

--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -289,7 +289,7 @@ orgs.newOrg('automotive.tractusx', 'eclipse-tractusx') {
         default_workflow_permissions: "write",
       },
     },
-    orgs.newRepo('aas-suite-python') {
+    orgs.newRepo('aas-suite') {
       allow_merge_commit: true,
       allow_update_branch: false,
       delete_branch_on_merge: false,
@@ -299,7 +299,7 @@ orgs.newOrg('automotive.tractusx', 'eclipse-tractusx') {
       gh_pages_source_branch: "gh-pages",
       gh_pages_source_path: "/",
       has_discussions: true,
-      homepage: "https://github.com/eclipse-tractusx/aas-suite-python",
+      homepage: "https://github.com/eclipse-tractusx/aas-suite",
       private_vulnerability_reporting_enabled: true,
       web_commit_signoff_required: false,
       environments: [


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

As described in this ticket: 

https://github.com/eclipse-tractusx/sig-release/issues/1467

Wind-X is willing to integrate the BaSyx Python SDK and the Tractus-X SDK in one runtime which is able to manage the Authorization and Usage Permissions in the EDC and provide Asset Administration Shells (AAS) as EDC Assets.

The idea is to create helm charts and host the images in docker hub, so therefore we need to create a repo to do the integration.

BaSyx Python SDK: https://github.com/eclipse-basyx/basyx-python-sdk
Tractus-X SDK: https://github.com/eclipse-tractusx/tractusx-sdk

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
