### PR TITLE
add two new repositories

### DIFF
--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -689,7 +689,7 @@ orgs.newOrg('automotive.tractusx', 'eclipse-tractusx') {
       allow_update_branch: false,
       delete_branch_on_merge: false,
       dependabot_security_updates_enabled: true,
-      description: "The new policy-builder allows the user to generate needed policies with an easy to use web interface.",
+      description: "This GUI allows to interact with the Tractus-X EDC Management API, including an easy to use policy builder.",
       gh_pages_build_type: "legacy",
       gh_pages_source_branch: "gh-pages",
       gh_pages_source_path: "/",

--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -684,7 +684,7 @@ orgs.newOrg('automotive.tractusx', 'eclipse-tractusx') {
         },
       ],
     },
-    orgs.newRepo('policy-builder') {
+    orgs.newRepo('tractusx-edc-dashboard') {
       allow_merge_commit: true,
       allow_update_branch: false,
       delete_branch_on_merge: false,

--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -404,6 +404,28 @@ orgs.newOrg('automotive.tractusx', 'eclipse-tractusx') {
         },
       ],
     },
+    orgs.newRepo('engineering-use-case-demonstrator') {
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      delete_branch_on_merge: false,
+      dependabot_security_updates_enabled: true,
+      description: "3D demonstrator for engineering use case",
+      gh_pages_build_type: "legacy",
+      gh_pages_source_branch: "gh-pages",
+      gh_pages_source_path: "/",
+      has_discussions: true,
+      homepage: "https://github.com/eclipse-tractusx/engineering-use-case-demonstrator",
+      private_vulnerability_reporting_enabled: true,
+      web_commit_signoff_required: false,
+      environments: [
+        orgs.newEnvironment('github-pages') {
+          branch_policies+: [
+            "gh-pages"
+          ],
+          deployment_branch_policy: "selected",
+        },
+      ],
+    },
     orgs.newRepo('industry-core-hub') {
       allow_merge_commit: true,
       allow_update_branch: false,
@@ -653,6 +675,28 @@ orgs.newOrg('automotive.tractusx', 'eclipse-tractusx') {
       workflows+: {
         default_workflow_permissions: "write",
       },
+      environments: [
+        orgs.newEnvironment('github-pages') {
+          branch_policies+: [
+            "gh-pages"
+          ],
+          deployment_branch_policy: "selected",
+        },
+      ],
+    },
+    orgs.newRepo('policy-builder') {
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      delete_branch_on_merge: false,
+      dependabot_security_updates_enabled: true,
+      description: "The new policy-builder allows the user to generate needed policies with an easy to use web interface.",
+      gh_pages_build_type: "legacy",
+      gh_pages_source_branch: "gh-pages",
+      gh_pages_source_path: "/",
+      has_discussions: true,
+      homepage: "https://github.com/eclipse-tractusx/policy-builder",
+      private_vulnerability_reporting_enabled: true,
+      web_commit_signoff_required: false,
       environments: [
         orgs.newEnvironment('github-pages') {
           branch_policies+: [

--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -694,7 +694,7 @@ orgs.newOrg('automotive.tractusx', 'eclipse-tractusx') {
       gh_pages_source_branch: "gh-pages",
       gh_pages_source_path: "/",
       has_discussions: true,
-      homepage: "https://github.com/eclipse-tractusx/policy-builder",
+      homepage: "https://eclipse-tractusx.github.io/tractusx-edc-dashboard",
       private_vulnerability_reporting_enabled: true,
       web_commit_signoff_required: false,
       environments: [


### PR DESCRIPTION
## Description

As described in issues https://github.com/eclipse-tractusx/sig-release/issues/1496 and https://github.com/eclipse-tractusx/sig-release/issues/1528, this PR creates to new repositories.

The content for the repositories will be an outcome of CX-NEXT.

contactpersons:

- policy-builder -> @juliapampus
- engineering-use-case-demonstrator -> @bosserf, @FEILSTE

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
