### PR TITLE
feat: deprecate digital-product-pass repository

### DIFF
--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -313,6 +313,7 @@ orgs.newOrg('automotive.tractusx', 'eclipse-tractusx') {
     },
     orgs.newRepo('digital-product-pass') {
       allow_merge_commit: true,
+      archived: true,
       allow_update_branch: false,
       delete_branch_on_merge: false,
       dependabot_security_updates_enabled: true,


### PR DESCRIPTION
## Description

As described in this issue #135 and prepared at the digital-product-pass repository we shall deprecate the repository.
I am starting now the process described in the TRG: https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-09

In two weeks if there is no problem we can merge this PR

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
