### PR TITLE
chore: add tractus-x-umbrella-iac repository

### DIFF
--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -1580,6 +1580,28 @@ orgs.newOrg('automotive.tractusx', 'eclipse-tractusx') {
         },
       ],
     },
+    orgs.newRepo('tractus-x-umbrella-iac') {
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      delete_branch_on_merge: false,
+      dependabot_security_updates_enabled: true,
+      description: "Infrastructure as Code for the Tractus-X Umbrella Helm Chart",
+      gh_pages_build_type: "legacy",
+      gh_pages_source_branch: "gh-pages",
+      gh_pages_source_path: "/",
+      has_discussions: true,
+      homepage: "https://eclipse-tractusx.github.io/tractus-x-umbrella-iac",
+      private_vulnerability_reporting_enabled: true,
+      web_commit_signoff_required: false,
+      environments: [
+        orgs.newEnvironment('github-pages') {
+          branch_policies+: [
+            "gh-pages"
+          ],
+          deployment_branch_policy: "selected",
+        },
+      ],
+    },
     orgs.newRepo('tractusx-edc') {
       allow_merge_commit: true,
       allow_update_branch: false,


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description

Creates a new Repository `tractus-x-umbrella-iac` for the Umbrella Helm Chart infrastructure as code.

https://github.com/eclipse-tractusx/tractus-x-umbrella/issues/395

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

### Contact
- Owner / Requester: @giterrific 
- Committer: @ds-jhartmann 
- Supporter(s): @mbauer55


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
