### PR TITLE
feat: Add 'tractusx-testlab' repository configuration

### DIFF
--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -1765,7 +1765,7 @@ orgs.newOrg('automotive.tractusx', 'eclipse-tractusx') {
         default_workflow_permissions: "write",
       },
     },
-    orgs.newRepo('tractusx-sdk-testlab') {
+    orgs.newRepo('tractusx-testlab') {
       allow_merge_commit: true,
       allow_update_branch: false,
       delete_branch_on_merge: false,
@@ -1775,7 +1775,7 @@ orgs.newOrg('automotive.tractusx', 'eclipse-tractusx') {
       gh_pages_source_branch: "gh-pages",
       gh_pages_source_path: "/",
       has_discussions: true,
-      homepage: "https://pypi.org/project/tractusx-sdk-testlab",
+      homepage: "https://pypi.org/project/tractusx-testlab",
       private_vulnerability_reporting_enabled: true,
       web_commit_signoff_required: false,
       environments: [

--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -1765,6 +1765,29 @@ orgs.newOrg('automotive.tractusx', 'eclipse-tractusx') {
         default_workflow_permissions: "write",
       },
     },
+    orgs.newRepo('tractusx-sdk-testlab') {
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      delete_branch_on_merge: false,
+      dependabot_security_updates_enabled: true,
+      description: "Eclipse Tractus-X SDK Test Lab - A dataspace native testing framework",
+      gh_pages_build_type: "legacy",
+      gh_pages_source_branch: "gh-pages",
+      gh_pages_source_path: "/",
+      has_discussions: true,
+      homepage: "https://pypi.org/project/tractusx-sdk-testlab",
+      private_vulnerability_reporting_enabled: true,
+      web_commit_signoff_required: false,
+      environments: [
+        orgs.newEnvironment('github-pages') {
+          branch_policies+: [
+            "gh-pages"
+          ],
+          deployment_branch_policy: "selected",
+        },
+        orgs.newEnvironment('pypi'),
+      ],
+    },
     orgs.newRepo('tractusx-sdk') {
       allow_merge_commit: true,
       allow_update_branch: false,

--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -1770,7 +1770,7 @@ orgs.newOrg('automotive.tractusx', 'eclipse-tractusx') {
       allow_update_branch: false,
       delete_branch_on_merge: false,
       dependabot_security_updates_enabled: true,
-      description: "Eclipse Tractus-X SDK Test Lab - A dataspace native testing framework",
+      description: "Eclipse Tractus-X Test Lab - A dataspace native testing framework which automates the usage of the tractusx-sdk for developing test case executables.",
       gh_pages_build_type: "legacy",
       gh_pages_source_branch: "gh-pages",
       gh_pages_source_path: "/",


### PR DESCRIPTION
Added configuration for new repository 'tractusx-sdk-testlab' with various settings including homepage and environment policies.

<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description

We from the Tractus-X SDK team want to create a new repository called: tractusx-testlab

So we can create scripts/configuration using our tractusx-sdk methods to execute certain tests using Tractus-X components or not. This testing framework should also support the automation of the E2E test phase from Eclipse Tractus-X products.

Here is the release ticket: https://github.com/eclipse-tractusx/sig-release/issues/1636


<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
