### PR TITLE
feat: add 'tractusx-fleet' repository configuration

### DIFF
--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -1896,5 +1896,25 @@ orgs.newOrg('automotive.tractusx', 'eclipse-tractusx') {
         default_workflow_permissions: "write",
       },
     },
+    orgs.newRepo('tractusx-fleet') {
+      description: "Fork - Fleet Management Components",
+      forked_repository: 'https://github.com/eclipse-edc/Fleet.git',
+      allow_merge_commit: true,
+      delete_branch_on_merge: true,
+      dependabot_security_updates_enabled: true,
+      gh_pages_build_type: "legacy",
+      gh_pages_source_branch: "gh-pages",
+      gh_pages_source_path: "/",
+      homepage: "https://eclipse-tractusx.github.io/tractusx-fleet",
+      private_vulnerability_reporting_enabled: true,
+      environments: [
+        orgs.newEnvironment('github-pages') {
+          branch_policies+: [
+            "gh-pages"
+          ],
+        deployment_branch_policy: "selected",
+        },
+      ]
+    },
   ],
 }

--- a/otterdog/eclipse-tractusx.jsonnet
+++ b/otterdog/eclipse-tractusx.jsonnet
@@ -1898,7 +1898,7 @@ orgs.newOrg('automotive.tractusx', 'eclipse-tractusx') {
     },
     orgs.newRepo('tractusx-fleet') {
       description: "Fork - Fleet Management Components",
-      forked_repository: 'https://github.com/eclipse-edc/Fleet.git',
+      forked_repository: 'eclipse-edc/Fleet',
       allow_merge_commit: true,
       delete_branch_on_merge: true,
       dependabot_security_updates_enabled: true,


### PR DESCRIPTION
## Description

Added configuration for new repository 'tractusx-fleet'

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
